### PR TITLE
Feature/integration test framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ build
 .envrc
 sendToDevs
 steam_appid.txt
+bin
+preferences
+*.displayconfig

--- a/build.gradle.kts.example
+++ b/build.gradle.kts.example
@@ -2,6 +2,15 @@ plugins {
     java
 }
 
+sourceSets {
+    main {
+        java.srcDirs("src/main/java")
+    }
+    test {
+        java.srcDirs("src/test/java")
+    }
+}
+
 /*
 Setup environment variables
 * stsInstallLocation should point to the Steam install directory
@@ -29,6 +38,16 @@ repositories {
 
 dependencies {
     compileOnly(files(modTheSpireLocation, baseModLocation, stsJar))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.0") // Update the version if necessary
+    testImplementation(files(modTheSpireLocation, baseModLocation, stsJar))
+    // LibGDX core
+    testImplementation("com.badlogicgames.gdx:gdx:1.12.0")
+    // LibGDX headless backend
+    testImplementation("com.badlogicgames.gdx:gdx-backend-headless:1.12.0")
+    // LibGDX natives (for headless backend)
+    testImplementation("com.badlogicgames.gdx:gdx-platform:1.12.0:natives-desktop")
+    
+    testImplementation("org.mockito:mockito-core:5.5.0")
 }
 
 
@@ -73,4 +92,26 @@ tasks.register<Copy>("buildAndCopyJAR") {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    testLogging {
+      events("passed", "skipped", "failed")
+      exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+      showExceptions = true
+      showCauses = true
+      showStackTraces = true
+      showStandardStreams = true
+    }
+}
+
+tasks.register("checkDependencyFiles") {
+    doLast {
+        val files = listOf(modTheSpireLocation, baseModLocation, stsJar)
+        files.forEach { path ->
+            val file = File(path)
+            if (file.exists()) {
+                println("Found: $path")
+            } else {
+                println("Not found: $path")
+            }
+        }
+    }
 }

--- a/src/main/java/str_exporter/SlayTheRelicsExporter.java
+++ b/src/main/java/str_exporter/SlayTheRelicsExporter.java
@@ -45,9 +45,9 @@ public class SlayTheRelicsExporter implements RelicGetSubscriber,
     public static SlayTheRelicsExporter instance = null;
     private static String version = "";
     private static long lastOkayBroadcast = 0;
-    private final Config config;
-    private final EBSClient ebsClient;
-    private final AuthManager authManager;
+    private static Config config;
+    private static EBSClient ebsClient;
+    private static AuthManager authManager;
     private long lastTipsCheck = System.currentTimeMillis();
     private long lastDeckCheck = System.currentTimeMillis();
     private boolean checkTipsNextUpdate = false;

--- a/src/main/java/str_exporter/config/Config.java
+++ b/src/main/java/str_exporter/config/Config.java
@@ -14,7 +14,7 @@ public class Config {
     private static final String OAUTH_SETTINGS = "oauth";
     private static final String USER_SETTINGS = "user";
     public final Gson gson = new Gson();
-    private final SpireConfig config;
+    private static SpireConfig config;
 
     public Config() throws IOException {
         Properties strDefaultSettings = new Properties();

--- a/src/test/java/str_exporter/builders/DeckJSONBuilderTest.java
+++ b/src/test/java/str_exporter/builders/DeckJSONBuilderTest.java
@@ -1,0 +1,15 @@
+package str_exporter.builders;
+
+import org.junit.jupiter.api.Test;
+
+import str_exporter.testutil.TestUtil;
+
+public class DeckJSONBuilderTest extends TestUtil {
+
+  // @Test
+  public void buildStarterDeck() throws Exception {
+    DeckJSONBuilder deckJsonBuilder = new DeckJSONBuilder(strConfig, "test");
+
+    System.out.println(strConfig.gson.toJson(deckJsonBuilder.buildMessage()));
+  }
+}

--- a/src/test/java/str_exporter/builders/StringCompressionTest.java
+++ b/src/test/java/str_exporter/builders/StringCompressionTest.java
@@ -1,0 +1,16 @@
+package str_exporter.builders;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import org.junit.jupiter.api.Test;
+
+public class StringCompressionTest {
+  // @Test
+  public void testCompress() {
+    // replace this with what you want to check
+    String input = "This is a test stringThis is a test stringThis is a test stringThis is a test stringa";
+    String compressed = StringCompression.compress(input);
+    assertNotNull(compressed);
+    System.out.println("Decompressed - "+input);
+    System.out.println("Compressed - "+compressed);
+  }
+}

--- a/src/test/java/str_exporter/client/EBSClientTest.java
+++ b/src/test/java/str_exporter/client/EBSClientTest.java
@@ -1,0 +1,21 @@
+package str_exporter.client;
+
+import org.junit.jupiter.api.Test;
+
+import str_exporter.builders.DeckJSONBuilder;
+import str_exporter.testutil.TestUtil;
+
+public class EBSClientTest extends TestUtil {
+  @Test
+  public void test() throws Exception {
+    loadDeckJSONFile("basic.json");
+
+    spireConfig.setString("api_url", "http://localhost:8080");
+
+    DeckJSONBuilder deckJsonBuilder = new DeckJSONBuilder(strConfig, "test");
+
+    String msg = strConfig.gson.toJson(deckJsonBuilder.buildMessage());
+
+    ebsClient.broadcastMessage(msg);
+  }
+}

--- a/src/test/java/str_exporter/client/EBSClientTest.java
+++ b/src/test/java/str_exporter/client/EBSClientTest.java
@@ -2,12 +2,27 @@ package str_exporter.client;
 
 import org.junit.jupiter.api.Test;
 
+// for example card add
+// import com.megacrit.cardcrawl.cards.AbstractCard;
+// import com.megacrit.cardcrawl.cards.blue.EchoForm;
+// import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+
 import str_exporter.builders.DeckJSONBuilder;
 import str_exporter.testutil.TestUtil;
 
 public class EBSClientTest extends TestUtil {
   @Test
   public void test() throws Exception {
+    // example way to add cards to the deck via the spire API
+    // import the card you want to add
+    // AbstractCard card = new EchoForm();
+
+    // upgrade the card
+    // card.upgrade();
+
+    // add the card to the deck
+    // AbstractDungeon.player.masterDeck.addToTop(card);
+
     loadDeckJSONFile("run-1728675795.json");
 
     spireConfig.setString("api_url", "http://localhost:8080");

--- a/src/test/java/str_exporter/client/EBSClientTest.java
+++ b/src/test/java/str_exporter/client/EBSClientTest.java
@@ -8,7 +8,7 @@ import str_exporter.testutil.TestUtil;
 public class EBSClientTest extends TestUtil {
   @Test
   public void test() throws Exception {
-    loadDeckJSONFile("basic.json");
+    loadDeckJSONFile("run-1728675795.json");
 
     spireConfig.setString("api_url", "http://localhost:8080");
 

--- a/src/test/java/str_exporter/testutil/TestUtil.java
+++ b/src/test/java/str_exporter/testutil/TestUtil.java
@@ -1,0 +1,324 @@
+package str_exporter.testutil;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.mockito.Mockito;
+
+import com.badlogic.gdx.ApplicationListener;
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.assets.AssetManager;
+import com.badlogic.gdx.backends.headless.HeadlessApplication;
+import com.badlogic.gdx.backends.headless.HeadlessApplicationConfiguration;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.GL20;
+import com.evacipated.cardcrawl.modthespire.Loader;
+import com.evacipated.cardcrawl.modthespire.ModInfo;
+import com.evacipated.cardcrawl.modthespire.lib.SpireConfig;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.characters.Defect;
+import com.megacrit.cardcrawl.characters.Ironclad;
+import com.megacrit.cardcrawl.characters.TheSilent;
+import com.megacrit.cardcrawl.characters.Watcher;
+import com.megacrit.cardcrawl.characters.AbstractPlayer.PlayerClass;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.core.CardCrawlGame;
+import com.megacrit.cardcrawl.core.Settings;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.helpers.CardLibrary;
+import com.megacrit.cardcrawl.helpers.FontHelper;
+import com.megacrit.cardcrawl.helpers.GameDictionary;
+import com.megacrit.cardcrawl.helpers.ImageMaster;
+import com.megacrit.cardcrawl.helpers.Prefs;
+import com.megacrit.cardcrawl.helpers.RelicLibrary;
+import com.megacrit.cardcrawl.helpers.TipTracker;
+import com.megacrit.cardcrawl.integrations.PublisherIntegration;
+import com.megacrit.cardcrawl.integrations.DistributorFactory.Distributor;
+import com.megacrit.cardcrawl.localization.LocalizedStrings;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import com.megacrit.cardcrawl.screens.DisplayOption;
+import com.megacrit.cardcrawl.unlock.UnlockTracker;
+
+import basemod.BaseMod;
+import str_exporter.SlayTheRelicsExporter;
+import str_exporter.client.EBSClient;
+import str_exporter.config.AuthManager;
+
+public class TestUtil {
+  private static HeadlessApplication application;
+  private static AssetManager assetManager;
+  public static CardCrawlGame game;
+  public static str_exporter.config.Config strConfig;
+  public static EBSClient ebsClient;
+  public static SpireConfig spireConfig;
+
+  private static void setupAppMocks() {
+    // Initialize the headless application
+    HeadlessApplicationConfiguration config = new HeadlessApplicationConfiguration();
+
+    application = new HeadlessApplication(new ApplicationListener() {
+      @Override
+      public void create() {
+      }
+
+      @Override
+      public void resize(int width, int height) {
+      }
+
+      @Override
+      public void render() {
+      }
+
+      @Override
+      public void pause() {
+      }
+
+      @Override
+      public void resume() {
+      }
+
+      @Override
+      public void dispose() {
+      }
+    }, config);
+
+    Gdx.graphics = application.getGraphics();
+
+    if (Gdx.files == null) {
+      Gdx.files = application.getFiles();
+    }
+    // Initialize AssetManager and load assets if necessary
+    assetManager = new AssetManager();
+
+    Gdx.gl = Mockito.mock(GL20.class);
+
+    Locale.setDefault(Locale.ENGLISH);
+  }
+
+  // all stubs/mocks in here were implemented as the errors came up, only supports
+  // the minimum functionality of the
+  // DeckJSONBuilder as of now
+  private static void setupGameMocks() throws Exception {
+    // Create a mock PublisherIntegration instance
+    PublisherIntegration mockIntegration = Mockito.mock(PublisherIntegration.class);
+
+    // Mock the getType() method
+    Mockito.when(mockIntegration.getType()).thenReturn(Distributor.STEAM);
+
+    // Access the private field using reflection
+    Field field = CardCrawlGame.class.getDeclaredField("publisherIntegration");
+    field.setAccessible(true);
+
+    // Set the field to the mock object
+    field.set(null, mockIntegration);
+
+    Settings.gamePref = new Prefs();
+    Settings.displayOptions = new ArrayList<DisplayOption>();
+    Settings.displayOptions.add(new DisplayOption(0, 0));
+
+    Settings.soundPref = new Prefs();
+
+    Loader.MODINFOS = new ModInfo[0];
+
+    field = BaseMod.class.getDeclaredField("keywordProperNames");
+    field.setAccessible(true);
+
+    // Set the field to the mock object
+    field.set(null, new HashMap<>());
+
+    field = BaseMod.class.getDeclaredField("keywordUniqueNames");
+    field.setAccessible(true);
+
+    field.set(null, new HashMap<>());
+
+    field = BaseMod.class.getDeclaredField("keywordUniquePrefixes");
+    field.setAccessible(true);
+
+    field.set(null, new HashMap<>());
+
+    strConfig = new str_exporter.config.Config();
+    strConfig.setUser("test");
+    strConfig.setOathToken("test");
+
+    spireConfig = new SpireConfig("slayTheRelics", "slayTheRelicsExporterConfig");
+    spireConfig.load();
+
+    field = str_exporter.config.Config.class.getDeclaredField("config");
+    field.setAccessible(true);
+
+    field.set(strConfig, spireConfig);
+
+    field = SlayTheRelicsExporter.class.getDeclaredField("config");
+    field.setAccessible(true);
+
+    field.set(null, strConfig);
+
+    ebsClient = new EBSClient(strConfig);
+
+    field = SlayTheRelicsExporter.class.getDeclaredField("ebsClient");
+    field.setAccessible(true);
+
+    field.set(null, ebsClient);
+
+    field = SlayTheRelicsExporter.class.getDeclaredField("authManager");
+    field.setAccessible(true);
+
+    field.set(null, new AuthManager(ebsClient, strConfig));
+  }
+
+  @BeforeAll
+  public static void setUpClass() throws Exception {
+    setupAppMocks();
+    setupGameMocks();
+
+    game = new CardCrawlGame("");
+
+    Settings.language = Settings.GameLanguage.ENG;
+    Settings.scale = 1.0f;
+
+    CardCrawlGame.languagePack = new LocalizedStrings();
+
+    AbstractCreature.initialize();
+    AbstractCard.initialize();
+    GameDictionary.initialize();
+    ImageMaster.initialize();
+    AbstractPower.initialize();
+    FontHelper.initialize();
+    // AbstractCard.initializeDynamicFrameWidths();
+
+    UnlockTracker.initialize();
+    CardLibrary.initialize();
+    RelicLibrary.initialize();
+    // InputHelper.initialize();
+    TipTracker.initialize();
+    // ModHelper.initialize();
+    // ShaderHelper.initializeShaders();
+    // UnlockTracker.retroactiveUnlock();
+    // CInputHelper.loadSettings();
+
+  }
+
+  @AfterAll
+  public static void tearDownClass() {
+    // Dispose AssetManager
+    if (assetManager != null) {
+      assetManager.dispose();
+    }
+
+    // Clean up headless application
+    if (application != null) {
+      application.exit();
+      application = null;
+    }
+  }
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    setupGame(PlayerClass.IRONCLAD);
+  }
+
+  public void setupGame(PlayerClass cPlayerClass) throws Exception {
+    switch (cPlayerClass) {
+      case IRONCLAD:
+        Constructor<Ironclad> ironcladConstructor = Ironclad.class.getDeclaredConstructor(String.class);
+        ironcladConstructor.setAccessible(true); // Bypass access control checks
+        AbstractDungeon.player = ironcladConstructor.newInstance("test");
+        break;
+
+      case THE_SILENT:
+        Constructor<TheSilent> silentConstructor = TheSilent.class.getDeclaredConstructor(String.class);
+        silentConstructor.setAccessible(true); // Bypass access control checks
+        AbstractDungeon.player = silentConstructor.newInstance("test");
+        break;
+
+      case DEFECT:
+        Constructor<Defect> defectConstructor = Defect.class.getDeclaredConstructor(String.class);
+        defectConstructor.setAccessible(true); // Bypass access control checks
+        AbstractDungeon.player = defectConstructor.newInstance("test");
+        break;
+
+      case WATCHER:
+        Constructor<Watcher> watcherConstructor = Watcher.class.getDeclaredConstructor(String.class);
+        watcherConstructor.setAccessible(true); // Bypass access control checks
+        AbstractDungeon.player = watcherConstructor.newInstance("test");
+        break;
+
+      default:
+        throw new Exception("Invalid player class");
+    }
+
+    // init calls at start of game minus the rendering
+    AbstractDungeon.player.initializeStarterDeck();
+
+    game.getDungeon("EXORDIUM", AbstractDungeon.player);
+    game.mode = CardCrawlGame.GameMode.GAMEPLAY;
+  }
+
+  public void loadDeckJSONFile(String filename) throws Exception {
+    FileHandle file = Gdx.files.classpath("str_exporter_testdata/" + filename);
+
+    String jsonStr = file.readString();
+
+    @SuppressWarnings("unchecked")
+    Map<String, Double> cardMap = strConfig.gson.fromJson(jsonStr, Map.class);
+
+    AbstractDungeon.player.masterDeck.clear();
+
+    cardMap.forEach((cardName, count) -> {
+      AbstractCard c = CardLibrary.getCard(cardName);
+      AbstractCard cCpy3 = null;
+      if (c == null) {
+        // for some cases the ID wont match the name of the card (like Recursion, which
+        // has the ID "Redo", or "Strike" with ID
+        // "Strike_R" for Ironclad), so check all cards by name
+        for (AbstractCard card : CardLibrary.getAllCards()) {
+          String name = card.name.replaceFirst("_(R|G|B|P)", ""); // because of this 
+          if (!name.equals(cardName)) {
+            continue;
+          }
+
+          // insert starter cards from the correct class
+          if (card.isStarterDefend() || card.isStarterStrike()) {
+            if (card.color != AbstractDungeon.player.getCardColor()) {
+              continue;
+            }
+          }
+
+          cCpy3 = card.makeCopy();
+          break;
+        }
+
+        if (cCpy3 == null) {
+          throw new RuntimeException("Card not found: " + cardName);
+        }
+      } else {
+        cCpy3 = c.makeCopy();
+      }
+
+      String[] cardNameSplit = cardName.split("\\+");
+      if (cardNameSplit.length == 2) {
+        int upgradeCount = 1;
+        if (cardNameSplit[1].length() > 0) {
+          upgradeCount = Integer.parseInt(cardNameSplit[1]);
+        }
+
+        for (int i = 0; i < upgradeCount; i++) {
+          cCpy3.upgrade();
+        }
+      }
+
+      for (int i = 0; i < count; i++) {
+        AbstractCard card = cCpy3.makeCopy();
+
+        AbstractDungeon.player.masterDeck.addToTop(card);
+      }
+    });
+  }
+}

--- a/src/test/resources/str_exporter_testdata/basic.json
+++ b/src/test/resources/str_exporter_testdata/basic.json
@@ -1,0 +1,1 @@
+{"Bash":1,"Defend":4,"Go for the Eyes":1,"Strike":5}

--- a/src/test/resources/str_exporter_testdata/run-1728675795.json
+++ b/src/test/resources/str_exporter_testdata/run-1728675795.json
@@ -1,0 +1,1 @@
+{"Ascender's Bane":1,"Ball Lightning":2,"Cold Snap":1,"Compile Driver":3,"Coolheaded":1,"Coolheaded+":1,"Creative AI":1,"Defend":3,"Defragment+":1,"Doom and Gloom+":1,"Dualcast":1,"Electrodynamics+":1,"Fission+":1,"Go for the Eyes":1,"Hologram":1,"Hologram+":1,"Purity":1,"Rainbow":1,"Reboot":1,"Recursion+":3,"Recycle":1,"Recycle+":1,"Self Repair":1,"Skim+":1,"Storm":1,"Zap":1}


### PR DESCRIPTION
Add `TestUtil` class for testing the mod with real Spire logic. Added stub setup necessary to get the deck dictionary and STR Exporter mod working without graphics context.

See [this commit](https://github.com/benw10-1/slay-the-relics/commit/af62d37c2392b9a75eee6ef2feaaf3b056aaf403) on the backend repo for collecting data from the `EBSClient` test.

Setup instructions (with vscode, seems to be easiest):
1. Install gradle extension on vscode
2. Make copy of build.gradle.kts.example and rename to it without the .example part
3. Change `stsInstallLocation` to your steam install location
4. Change `steamappsLocation` to your steamapps folder (can usually be found from sts install location)
  a. If you want to use a folder for any version of "BaseMod" or "ModTheSpire" change the location vars to point to their locations. HOWEVER, there are issues with using the release versions, seems like some deps are missing from the version you download from the workshop (not an expert idk)
5. Go to `gradle` tab on bottom left. Click "verification" then click the run button for "test"
  a. If getting compile import errors, check that you are pointing to the correct jars. Try downloading from the workshop and copying into local and see if that fixes.
  b. If getting compile import errors can check if gradle is actually seeing the files via `checkDependencyFiles`